### PR TITLE
fix: do not duplicate sasl configuration entries on restart

### DIFF
--- a/scripts/common-run.sh
+++ b/scripts/common-run.sh
@@ -349,7 +349,7 @@ postfix_setup_smtpd_sasl_auth() {
 		do_postconf -e "broken_sasl_auth_clients=yes"
 		
 		[ ! -d /etc/postfix/sasl ] && mkdir /etc/postfix/sasl
-		cat >> /etc/postfix/sasl/smtpd.conf <<EOF
+		cat > /etc/postfix/sasl/smtpd.conf <<EOF
 pwcheck_method: auxprop
 auxprop_plugin: sasldb
 mech_list: PLAIN LOGIN CRAM-MD5 DIGEST-MD5 NTLM


### PR DESCRIPTION
Fixing the issue when container will not restart due to sasl config file error